### PR TITLE
Fix broken blog links

### DIFF
--- a/data/blogs.json
+++ b/data/blogs.json
@@ -22,9 +22,16 @@
             "author": "Aritra Mukhopadhyay"
         },
         {
+            "title": "Introduction: Linear Regression and Gradient Descent",
+            "abstract": "Although this will be a walk through the concept of Linear Regression, mainly from the point of view of Machine Learning, we will also touch upon the mathematical aspects of it and its uses in Statistical data analysis (which is primarily relevant to our lab experiments).",
+            "link": "https://sdgniser.github.io/coding_club_blogs/blogs/2024/03/24/linear-regression-and-gradient-descent.html",
+            "date": "Mar 24, 2024",
+            "author": "Aritra Mukhopadhyay"
+        },
+        {
             "title": "Why Neural Network",
             "abstract": "We want to build an intelligent system. But why neural networks? In this, we will explore the concept of universal approximation, which states that neural networks can theoretically approximate any function, given enough hidden units and a suitable activation function.",
-            "link": "https://sdgniser.github.io/coding_club_blogs/blogs/2024/03/24/linear-regression-and-gradient-descent.html",
+            "link": "https://sdgniser.github.io/coding_club_blogs/blogs/2023/11/25/Why-Neural-Network.html",
             "date": "Nov 25, 2023",
             "author": "Shriman Keshri"
         },

--- a/data/blogs.json
+++ b/data/blogs.json
@@ -3,28 +3,28 @@
         {
             "title": "Git & GitHub: An Invitation to Version Control",
             "abstract": "This blogpost is a slightly expanded conversion of a talk, I gave to the students of CS460/CS660 at NISER, Bhubaneswar, on January 12, 2024. It is a tutorial-style introduction to Git & GitHub, and how to use them for version control. This blogpost / talk is meant for beginners, and assumes no prior knowledge of Git or GitHub. It is also meant to be interactive, so that the readers can follow along and try out the git commands themselves.",
-            "link": "https://sdgniser.github.io/coding_club_blogs/jekyll/update/2024/01/12/git-and-github.html",
+            "link": "https://sdgniser.github.io/coding_club_blogs/blogs/2024/01/12/git-and-github.html",
             "date": "Jan 12, 2024",
             "author": "Jyotirmaya Shivottam"
         },
         {
             "title": "Remote Devlopment on SSH Servers",
             "abstract": "Secure Shell servers, are used for providing secure and encrypted access to remote servers. Here we dive into the details of these servers, covering topics like creating servers, setting up environments, updating projects, and running code.",
-            "link": "https://sdgniser.github.io/coding_club_blogs/jekyll/update/2024/01/06/ssh-servers.html",
+            "link": "https://sdgniser.github.io/coding_club_blogs/blogs/2024/01/06/ssh-servers.html",
             "date": "Jan 6, 2024",
             "author": "Sagar Prakash Barad"
         },
         {
             "title": "Markdown",
             "abstract": "Here we focus on the fundamentals of Git & GitHub, covering basic concepts like commits, branches, pull requests (PRs), merges, and integration with other tools used by coders, such as VS Code.",
-            "link": "https://sdgniser.github.io/coding_club_blogs/jekyll/update/2023/12/29/markdown.html",
+            "link": "https://sdgniser.github.io/coding_club_blogs/blogs/2023/12/29/markdown.html",
             "date": "Dec 29, 2023",
             "author": "Aritra Mukhopadhyay"
         },
         {
             "title": "Why Neural Network",
             "abstract": "We want to build an intelligent system. But why neural networks? In this, we will explore the concept of universal approximation, which states that neural networks can theoretically approximate any function, given enough hidden units and a suitable activation function.",
-            "link": "https://sdgniser.github.io/coding_club_blogs/jekyll/update/2023/11/25/Why-Neural-Network.html",
+            "link": "https://sdgniser.github.io/coding_club_blogs/blogs/2024/03/24/linear-regression-and-gradient-descent.html",
             "date": "Nov 25, 2023",
             "author": "Shriman Keshri"
         },


### PR DESCRIPTION
Links to coding club blogs were broken. Fixed by changing the links in blogs.json.